### PR TITLE
RedHat family compatibility and HTTPS by default

### DIFF
--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -5,8 +5,7 @@ datadog-apt-https:
 {% endif %}
 
 datadog-repo:
-  pkgrepo:
-    - managed
+  pkgrepo.managed:
     - humanname: "Datadog Agent"
     {% if grains['os'].lower() in ('ubuntu', 'debian') %}
     - name: deb http://apt.datadoghq.com/ stable main
@@ -15,14 +14,16 @@ datadog-repo:
     - file: /etc/apt/sources.list.d/datadog.list
     - require:
       - pkg: datadog-apt-https
-    {% elif grains['os'].lower() == 'redhat' %}
-    - name: Datadog, Inc.
+    {% elif grains['os'].lower() in ('redhat', 'centos', 'amazon') %}
+    - name: datadog-repo
     - baseurl: http://yum.datadoghq.com/rpm/x86_64
+    - gpgcheck: '0'
     {% endif %}
  
 datadog-pkg:
   pkg.latest:
     - name: datadog-agent
+    - refresh: True
     - require:
       - pkgrepo: datadog-repo
  

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -1,4 +1,4 @@
-{% if grains['os'].lower() in ('ubuntu', 'debian') %}
+{% if grains['os_family'].lower() in 'debian' %}
 datadog-apt-https:
   pkg.installed:
     - name: apt-transport-https

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -1,4 +1,4 @@
-{% if grains['os_family'].lower() in 'debian' %}
+{% if grains['os_family'].lower() == 'debian' %}
 datadog-apt-https:
   pkg.installed:
     - name: apt-transport-https

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -15,7 +15,7 @@ datadog-repo:
     - require:
       - pkg: datadog-apt-https
     {% elif grains['os_family'].lower() == 'redhat' %}
-    - name: datadog-repo
+    - name: datadog-agent
     - baseurl: https://yum.datadoghq.com/rpm/x86_64
     - gpgcheck: '0'
     {% endif %}

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -8,7 +8,7 @@ datadog-repo:
   pkgrepo.managed:
     - humanname: "Datadog Agent"
     {% if grains['os'].lower() in ('ubuntu', 'debian') %}
-    - name: deb http://apt.datadoghq.com/ stable main
+    - name: deb https://apt.datadoghq.com/ stable main
     - keyserver: keyserver.ubuntu.com
     - keyid: C7A7DA52
     - file: /etc/apt/sources.list.d/datadog.list
@@ -16,7 +16,7 @@ datadog-repo:
       - pkg: datadog-apt-https
     {% elif grains['os'].lower() in ('redhat', 'centos', 'amazon') %}
     - name: datadog-repo
-    - baseurl: http://yum.datadoghq.com/rpm/x86_64
+    - baseurl: https://yum.datadoghq.com/rpm/x86_64
     - gpgcheck: '0'
     {% endif %}
  

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -6,7 +6,7 @@ datadog-apt-https:
 
 datadog-repo:
   pkgrepo.managed:
-    - humanname: "Datadog Agent"
+    - humanname: "Datadog, Inc."
     {% if grains['os_family'].lower() == 'debian' %}
     - name: deb https://apt.datadoghq.com/ stable main
     - keyserver: keyserver.ubuntu.com
@@ -15,9 +15,11 @@ datadog-repo:
     - require:
       - pkg: datadog-apt-https
     {% elif grains['os_family'].lower() == 'redhat' %}
-    - name: datadog-agent
-    - baseurl: https://yum.datadoghq.com/rpm/x86_64
-    - gpgcheck: '0'
+    - name: datadog
+    - baseurl: https://yum.datadoghq.com/rpm/{{ grains['cpuarch'] }}
+    - gpgcheck: '1'
+    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    - sslverify: '1'
     {% endif %}
  
 datadog-pkg:

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -7,14 +7,14 @@ datadog-apt-https:
 datadog-repo:
   pkgrepo.managed:
     - humanname: "Datadog Agent"
-    {% if grains['os'].lower() in ('ubuntu', 'debian') %}
+    {% if grains['os_family'].lower() == 'debian' %}
     - name: deb https://apt.datadoghq.com/ stable main
     - keyserver: keyserver.ubuntu.com
     - keyid: C7A7DA52
     - file: /etc/apt/sources.list.d/datadog.list
     - require:
       - pkg: datadog-apt-https
-    {% elif grains['os'].lower() in ('redhat', 'centos', 'amazon') %}
+    {% elif grains['os_family'].lower() == 'redhat' %}
     - name: datadog-repo
     - baseurl: https://yum.datadoghq.com/rpm/x86_64
     - gpgcheck: '0'


### PR DESCRIPTION
## What
- Formula was not working for RedHat OS family; added for compatibility
- Used `os_family` for better compatibility between OS installations
- Datadog-agent package needs a repo refresh on first installed
- Formula was requiring HTTPS repo support (example: apt-transport-https on Debian based systems) without actually using HTTPS, so changed URLs to HTTPS
- Set `gpgcheck` to `1`, and added public gpgkey to formula for verification
- Set `sslverify` to `1` to verify the HTTPS endpoint
- Added `cpuarch` grain to be more compatible with Datadog's repo structure for RPM based installations

## Test
* Run a `salt '*' state.show_sls` to get proper highstate output
* Run a `salt '*' state.highstate test=True` on each environment before pushing changes
* Run a `salt-call cp.get_template salt://<file-uri> /dev/stdout` to test out any relevant Jinja templates on the targeted hosts