### PR TITLE
Configure checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ Available States
 ``datadog``
 -----------
 
-Installs and runs the Datadog agent.
+Installs, configures, and runs the Datadog agent.
 
-This formula uses pillar data to store the Datadog API key for your account (see ``pillar.example``).
+This formula uses the Salt pillar to configure Datadog checks. Since both
+Salt and Datadog use YAML for configuration, it's simple to essentially copy
+pillar data directly into Datadog check configuration files. Use the same
+syntax specified in any <check>.yaml.example. Your current configs can be 
+copied verbatim into the Salt pillar (see ``pillar.example``).

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,14 @@ Available States
 
 Installs, configures, and runs the Datadog agent.
 
-This formula uses the Salt pillar to configure Datadog checks. Since both
-Salt and Datadog use YAML for configuration, it's simple to essentially copy
-pillar data directly into Datadog check configuration files. Use the same
-syntax specified in any <check>.yaml.example. Your current configs can be 
-copied verbatim into the Salt pillar (see ``pillar.example``).
+This formula uses the Salt pillar to configure Datadog and Datadog checks. Since
+both Salt and Datadog use YAML for configuration, it's simple to essentially copy
+pillar data directly into Datadog check configuration files. Use the same syntax
+specified in any <check>.yaml.example. Your current configs can be copied
+verbatim into the Salt pillar (see ``pillar.example``).
+
+**NOTE:** In order to split a single check type's configuration among multiple
+pillar files (eg. to configure different check instances on different machines),
+the `pillar_merge_lists` option must be set to `True` in the Salt master config
+(or the salt minion config if running masterless) (see 
+https://docs.saltstack.com/en/latest/ref/configuration/master.html#pillar-merge-lists).

--- a/datadog/files/check_type.yaml.jinja
+++ b/datadog/files/check_type.yaml.jinja
@@ -1,0 +1,5 @@
+{% if pillar.datadog[check_type].init_config is not defined -%}
+init_config:
+
+{% endif -%}
+{{ pillar.datadog[check_type] | yaml(False) }}

--- a/datadog/files/datadog.conf.jinja
+++ b/datadog/files/datadog.conf.jinja
@@ -1,0 +1,2 @@
+[Main]
+{{ pillar.datadog.config | yaml(False) }}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,8 @@ datadog:
   config:
     api_key: apikey_3
   process:
+    init_config:
+      procfs_path: /proc
     instances:
       - name: ssh
         search_string: ['sshd']

--- a/pillar.example
+++ b/pillar.example
@@ -1,2 +1,12 @@
 datadog:
-  api_key: apikey_3
+  config:
+    api_key: apikey_3
+  process:
+    instances:
+      - name: ssh
+        search_string: ['sshd']
+  tcp_check:
+    instances:
+      - host: 127.0.0.1
+        name: sshd
+        port: 22


### PR DESCRIPTION
This pull request is to add the ability configure all Datadog checks through Salt.

Since both Salt and Datadog use YAML for configuration, it's simple to essentially copy pillar data directly into Datadog check configuration files. This allows us to configure all Datadog checks through the Salt pillar which gives us the power to easily define different checks for different servers.