### PR TITLE
Make datadog.checks optional

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -23,6 +23,7 @@ datadog-conf:
       - cmd: datadog-example
 {% endif %}
 
+{% if datadog.checks is defined %}
 {% for check_name in datadog.checks %}
 datadog_{{ check_name }}_yaml_installed:
   file.managed:
@@ -35,3 +36,4 @@ datadog_{{ check_name }}_yaml_installed:
     - context:
         check_name: {{ check_name }}
 {% endfor %}
+{% endif %}

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -10,4 +10,6 @@ datadog-agent-service:
     - watch:
       - pkg: datadog-agent
       - file: {{ datadog.config }}
+{% if datadog.checks is defined %}
       - file: {{ datadog.checks_config }}/*
+{% endif %}


### PR DESCRIPTION
Make pillardata for checks optional. Allows for separation of different
checks for different roles/hosts.

Test by removing "checks:" from pillars.

Test by adding separate pillar file with:
```
datadog:
  checks:
    mycheck:
      init_config:
      instances:
        - name: foo
```