### PR TITLE
[install] Use long apt key fingerprint

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -24,7 +24,7 @@ datadog-repo:
         {%- endif %}
     - name: deb https://apt.datadoghq.com/ {{ distribution }} {{ packages }}
     - keyserver: keyserver.ubuntu.com
-    - keyid: 382E94DE
+    - keyid: A2923DFF56EDA6E76E55E492D3A80E30382E94DE
     - file: /etc/apt/sources.list.d/datadog.list
     - require:
       - pkg: datadog-apt-https


### PR DESCRIPTION
Use of short GPG key fingerprints should be avoided because of the high risk of collisions there is with those.
This replaces the short apt key fingerprint with the long one.