### PR TITLE
[install] Trust the new RPM GPG key on RHEL

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -43,7 +43,7 @@ datadog-repo:
     - name: datadog
     - baseurl: https://yum.datadoghq.com/{{ path }}/{{ grains['cpuarch'] }}
     - gpgcheck: '1'
-    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY.public
     - sslverify: '1'
     {% endif %}
 


### PR DESCRIPTION
In the near future, the Agent packages will be signed with
our newer GPG key. In preparation for this, the RHEL install
should import the new associated public key.