### PR TITLE
Add site option

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -12,7 +12,7 @@ datadog-example:
       - pkg: datadog-pkg
 
 {% if datadog_settings.api_key is defined %}
-datadog-conf:
+datadog-conf-api-key:
   file.replace:
     - name: {{ config_file_path }}
     - pattern: "api_key:(.*)"
@@ -24,7 +24,7 @@ datadog-conf:
 {% endif %}
 
 {% if datadog_settings.site is defined %}
-datadog-conf:
+datadog-conf-site:
   file.replace:
     - name: {{ config_file_path }}
     - pattern: "(.*)site:(.*)"

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -23,17 +23,19 @@ datadog-conf-api-key:
       - pkg: datadog-pkg
 {% endif %}
 
-{% if datadog_settings.site is defined %}
 datadog-conf-site:
   file.replace:
     - name: {{ config_file_path }}
     - pattern: "(.*)site:(.*)"
+{% if datadog_settings.site is defined %}
     - repl: "site: {{ datadog_settings.site }}"
+{% else %}
+    - repl: "# site: datadoghq.com"
+{% endif %}
     - count: 1
     - onlyif: test -f {{ config_file_path }}
     - watch:
       - pkg: datadog-pkg
-{% endif %}
 
 {% if datadog_settings.checks is defined %}
 {% for check_name in datadog_settings.checks %}

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -23,6 +23,18 @@ datadog-conf:
       - pkg: datadog-pkg
 {% endif %}
 
+{% if datadog_settings.site is defined %}
+datadog-conf:
+  file.replace:
+    - name: {{ config_file_path }}
+    - pattern: "(.*)site:(.*)"
+    - repl: "site: {{ datadog_settings.site }}"
+    - count: 1
+    - onlyif: test -f {{ config_file_path }}
+    - watch:
+      - pkg: datadog-pkg
+{% endif %}
+
 {% if datadog_settings.checks is defined %}
 {% for check_name in datadog_settings.checks %}
 datadog_{{ check_name }}_yaml_installed:

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,6 @@
 datadog:
   api_key: aaaaaaaabbbbbbbbccccccccdddddddd
+  site: datadoghq.com
   checks:
     process:
       init_config:

--- a/test/pillar/datadog.sls
+++ b/test/pillar/datadog.sls
@@ -1,5 +1,6 @@
 datadog:
   api_key: aaaaaaaabbbbbbbbccccccccdddddddd
+  site: datadoghq.com
   checks:
     directory:
       instances:


### PR DESCRIPTION
Allow adding a `site` option in the pillar file to set the same option in the minions' `datadog.yaml` files.