### PR TITLE
Add python_version option

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -37,6 +37,20 @@ datadog-conf-site:
     - watch:
       - pkg: datadog-pkg
 
+datadog-conf-python-version:
+  file.replace:
+    - name: {{ config_file_path }}
+    - pattern: "(.*)python_version:(.*)"
+{% if datadog_settings.python_version is defined %}
+    - repl: "python_version: {{ datadog_settings.python_version }}"
+{% else %}
+    - repl: "# python_version: 2"
+{% endif %}
+    - count: 1
+    - onlyif: test -f {{ config_file_path }}
+    - watch:
+      - pkg: datadog-pkg
+
 {% if datadog_settings.checks is defined %}
 {% for check_name in datadog_settings.checks %}
 datadog_{{ check_name }}_yaml_installed:

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,7 @@
 datadog:
   api_key: aaaaaaaabbbbbbbbccccccccdddddddd
   site: datadoghq.com
+  python_version: 2
   checks:
     process:
       init_config:

--- a/test/pillar/datadog.sls
+++ b/test/pillar/datadog.sls
@@ -1,6 +1,7 @@
 datadog:
   api_key: aaaaaaaabbbbbbbbccccccccdddddddd
   site: datadoghq.com
+  python_version: 2
   checks:
     directory:
       instances:


### PR DESCRIPTION
Allow adding a `python_version` option to choose which python version is loaded at runtime, since that option will be available in the Datadog Agent version 6.14.0.

