### PR TITLE
[pillar] Revamp pillar file structure & allow arbitrary keys in datadog.yaml

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -1,61 +1,22 @@
-{% from "datadog/map.jinja" import datadog_settings with context %}
-{% set config_file_path = '%s/%s'|format(datadog_settings.config_folder, datadog_settings.config_file) -%}
-{% set example_file_path = '%s.example'|format(config_file_path) -%}
+{% from "datadog/map.jinja" import datadog_config, datadog_install_settings, datadog_checks with context %}
+{% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
-datadog-example:
-  file.copy:
+datadog_conf_installed:
+  file.managed:
     - name: {{ config_file_path }}
-    - source: {{ example_file_path }}
-    # file.copy will not overwrite a named file, so we only need to check if the example config file exists
-    - onlyif: test -f {{ example_file_path }}
+    - source: salt://datadog/files/datadog.yaml.jinja
+    - user: dd-agent
+    - group: dd-agent
+    - mode: 600
+    - template: jinja
     - require:
       - pkg: datadog-pkg
 
-{% if datadog_settings.api_key is defined %}
-datadog-conf-api-key:
-  file.replace:
-    - name: {{ config_file_path }}
-    - pattern: "api_key:(.*)"
-    - repl: "api_key: {{ datadog_settings.api_key }}"
-    - count: 1
-    - onlyif: test -f {{ config_file_path }}
-    - watch:
-      - pkg: datadog-pkg
-{% endif %}
-
-datadog-conf-site:
-  file.replace:
-    - name: {{ config_file_path }}
-    - pattern: "(.*)site:(.*)"
-{% if datadog_settings.site is defined %}
-    - repl: "site: {{ datadog_settings.site }}"
-{% else %}
-    - repl: "# site: datadoghq.com"
-{% endif %}
-    - count: 1
-    - onlyif: test -f {{ config_file_path }}
-    - watch:
-      - pkg: datadog-pkg
-
-datadog-conf-python-version:
-  file.replace:
-    - name: {{ config_file_path }}
-    - pattern: "(.*)python_version:(.*)"
-{% if datadog_settings.python_version is defined %}
-    - repl: "python_version: {{ datadog_settings.python_version }}"
-{% else %}
-    - repl: "# python_version: 2"
-{% endif %}
-    - count: 1
-    - onlyif: test -f {{ config_file_path }}
-    - watch:
-      - pkg: datadog-pkg
-
-{% if datadog_settings.checks is defined %}
-{% for check_name in datadog_settings.checks %}
+{% if datadog_checks is defined %}
+{% for check_name in datadog_checks %}
 datadog_{{ check_name }}_yaml_installed:
   file.managed:
-    - name: {{ datadog_settings.checks_confd }}/{{ check_name }}.yaml
+    - name: {{ datadog_install_settings.checks_confd }}/{{ check_name }}.yaml
     - source: salt://datadog/files/conf.yaml.jinja
     - user: dd-agent
     - group: root

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -1,7 +1,19 @@
-{% from "datadog/map.jinja" import datadog_config, datadog_install_settings, datadog_checks with context %}
+{% from "datadog/map.jinja" import datadog_config, datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
 {% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
+{%- if not latest_agent_version and parsed_version[1] == '5' %}
 datadog_conf_installed:
+  file.managed:
+    - name: {{ config_file_path }}
+    - source: salt://datadog/files/datadog.conf.jinja
+    - user: dd-agent
+    - group: dd-agent
+    - mode: 600
+    - template: jinja
+    - require:
+      - pkg: datadog-pkg
+{%- else %}
+datadog_yaml_installed:
   file.managed:
     - name: {{ config_file_path }}
     - source: salt://datadog/files/datadog.yaml.jinja
@@ -11,6 +23,7 @@ datadog_conf_installed:
     - template: jinja
     - require:
       - pkg: datadog-pkg
+{%- endif %}
 
 {% if datadog_checks is defined %}
 {% for check_name in datadog_checks %}

--- a/datadog/files/conf.yaml.jinja
+++ b/datadog/files/conf.yaml.jinja
@@ -1,5 +1,7 @@
-{% if pillar.datadog.checks[check_name].init_config is not defined -%}
+{% from "datadog/map.jinja" import datadog_checks with context -%}
+
+{% if datadog_checks[check_name].init_config is not defined -%}
 init_config:
 {% endif -%}
 
-{{ pillar.datadog.checks[check_name] | yaml(False) }}
+{{ datadog_checks[check_name] | yaml(False) }}

--- a/datadog/files/datadog.conf.jinja
+++ b/datadog/files/datadog.conf.jinja
@@ -4,7 +4,7 @@
 dd_url: https://app.datadoghq.com
 
 {% if datadog_config.api_key is not defined -%}
-apt_key:
+api_key:
 {% else -%}
 api_key: {{ datadog_config.api_key }}
 {% endif -%}

--- a/datadog/files/datadog.conf.jinja
+++ b/datadog/files/datadog.conf.jinja
@@ -1,0 +1,10 @@
+{% from "datadog/map.jinja" import datadog_config with context -%}
+
+[Main]
+dd_url: https://app.datadoghq.com
+
+{% if datadog_config.api_key is not defined -%}
+apt_key:
+{% else -%}
+api_key: {{ datadog_config.api_key }}
+{% endif -%}

--- a/datadog/files/datadog.yaml.jinja
+++ b/datadog/files/datadog.yaml.jinja
@@ -4,4 +4,6 @@
 api_key:
 {% endif -%}
 
+{% if datadog_config | length -%}
 {{ datadog_config | yaml(False) }}
+{% endif -%}

--- a/datadog/files/datadog.yaml.jinja
+++ b/datadog/files/datadog.yaml.jinja
@@ -1,0 +1,7 @@
+{% from "datadog/map.jinja" import datadog_config with context -%}
+
+{% if datadog_config.api_key is not defined -%}
+api_key:
+{% endif -%}
+
+{{ datadog_config | yaml(False) }}

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -1,4 +1,4 @@
 include:
-  - datadog.config
   - datadog.install
+  - datadog.config
   - datadog.service

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_settings, latest_agent_version, parsed_version with context %}
+{% from "datadog/map.jinja" import datadog_install_settings, latest_agent_version, parsed_version with context %}
 
 {%- if grains['os_family'].lower() == 'debian' %}
 datadog-apt-https:
@@ -49,13 +49,13 @@ datadog-repo:
 
 datadog-pkg:
   pkg.installed:
-    - name: {{ datadog_settings.pkg_name }}
+    - name: {{ datadog_install_settings.pkg_name }}
     {%- if latest_agent_version %}
     - version: 'latest'
     {%- elif grains['os_family'].lower() == 'debian' %}
-    - version: 1:{{ datadog_settings.agent_version }}-1
+    - version: 1:{{ datadog_install_settings.agent_version }}-1
     {%- elif grains['os_family'].lower() == 'redhat' %}
-    - version: {{ datadog_settings.agent_version }}-1
+    - version: {{ datadog_install_settings.agent_version }}-1
     {%- endif %}
     - ignore_epoch: True
     - refresh: True

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -7,48 +7,56 @@
 
 {% set default_settings = {
     'datadog': {
-        'pkg_name': 'datadog-agent',
-        'service_name': 'datadog-agent',
-        'api_key': 'aaaaaaaabbbbbbbbccccccccdddddddd',
-        'agent_version': 'latest',
+        'config': {},
+        'checks': {},
+        'install_settings': {
+            'agent_version': 'latest',
+            'pkg_name': 'datadog-agent',
+            'service_name': 'datadog-agent',
+        },
+
     }
 }%}
 
 {# Merge os_family_map into the default settings #}
-{% do default_settings.datadog.update(os_family_map) %} 
+{% do default_settings.datadog.update(os_family_map) %}
 
 {# Merge in datadog pillar #}
-{% set datadog_settings = salt['pillar.get']('datadog', default=default_settings.datadog, merge=True) %}
+{% set datadog = salt['pillar.get']('datadog', default=default_settings.datadog, merge=True) %}
+{% set datadog_config = datadog['config'] %}
+{% set datadog_checks = datadog['checks'] %}
+{% set datadog_install_settings = datadog['install_settings'] %}
 
 {# Determine if we're looking for the latest package or a specific version #}
-{%- if datadog_settings.agent_version == 'latest' %}
+{%- if datadog_install_settings.agent_version == 'latest' %}
     {%- set latest_agent_version = true %}
 {%- else %}
     {%- set latest_agent_version = false %}
-    {%- set parsed_version = datadog_settings.agent_version | regex_match('(([0-9]+)\.[0-9]+\.[0-9]+)(?:~(rc|beta)\.([0-9]+-[0-9]+))?') %}
+    {%- set parsed_version = datadog_install_settings.agent_version | regex_match('(([0-9]+)\.[0-9]+\.[0-9]+)(?:~(rc|beta)\.([0-9]+-[0-9]+))?') %}
 {%- endif %}
 
+
 {# Determine defaults depending on specified version #}
-{% if 'config_folder' not in datadog_settings %}
+{% if 'config_folder' not in datadog_install_settings %}
     {%- if latest_agent_version or parsed_version[1] == '6' %}
-        {% do datadog_settings.update({'config_folder': '/etc/datadog-agent'}) %}
+        {% do datadog_install_settings.update({'config_folder': '/etc/datadog-agent'}) %}
     {%- else %}
-        {% do datadog_settings.update({'config_folder': '/etc/dd-agent'}) %}
+        {% do datadog_install_settings.update({'config_folder': '/etc/dd-agent'}) %}
     {%- endif %}
 {% endif %}
 
-{% if 'config_file' not in datadog_settings %}
+{% if 'config_file' not in datadog_install_settings %}
     {%- if latest_agent_version or parsed_version[1] == '6' %}
-        {% do datadog_settings.update({'config_file': 'datadog.yaml'}) %}
+        {% do datadog_install_settings.update({'config_file': 'datadog.yaml'}) %}
     {%- else %}
-        {% do datadog_settings.update({'config_file': 'datadog.conf'}) %}
+        {% do datadog_install_settings.update({'config_file': 'datadog.conf'}) %}
     {%- endif %}
 {% endif %}
 
-{% if 'checks_confd' not in datadog_settings %}
+{% if 'checks_confd' not in datadog_install_settings %}
     {%- if latest_agent_version or parsed_version[1] == '6' %}
-        {% do datadog_settings.update({'checks_confd': '/etc/datadog-agent/conf.d'}) %}
+        {% do datadog_install_settings.update({'checks_confd': '/etc/datadog-agent/conf.d'}) %}
     {%- else %}
-        {% do datadog_settings.update({'checks_confd': '/etc/dd-agent/conf.d'}) %}
+        {% do datadog_install_settings.update({'checks_confd': '/etc/dd-agent/conf.d'}) %}
     {%- endif %}
 {% endif %}

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -1,13 +1,13 @@
-{% from "datadog/map.jinja" import datadog_settings with context %}
-{% set config_file_path = '%s/%s'|format(datadog_settings.config_folder, datadog_settings.config_file) -%}
+{% from "datadog/map.jinja" import datadog_install_settings, datadog_checks with context %}
+{% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
 datadog-agent-service:
   service.running:
-    - name: {{ datadog_settings.service_name }}
+    - name: {{ datadog_install_settings.service_name }}
     - enable: True
     - watch:
-      - pkg: {{ datadog_settings.pkg_name }}
+      - pkg: {{ datadog_install_settings.pkg_name }}
       - file: {{ config_file_path }}
-{%- if datadog_settings.checks is defined %}
-      - file: {{ datadog_settings.checks_confd }}/*
+{%- if datadog_checks | length %}
+      - file: {{ datadog_install_settings.checks_confd }}/*
 {% endif %}

--- a/datadog/uninstall.sls
+++ b/datadog/uninstall.sls
@@ -1,11 +1,11 @@
-{% from "datadog/map.jinja" import datadog_settings with context %}
+{% from "datadog/map.jinja" import datadog_install_settings with context %}
 
 datadog-uninstall:
   service.dead:
-    - name: {{ datadog_settings.service_name }}
+    - name: {{ datadog_install_settings.service_name }}
     - enable: False
   pkg.removed:
     - pkgs:
-      - {{ datadog_settings.pkg_name }}
+      - {{ datadog_install_settings.pkg_name }}
     - require:
       - service: datadog-uninstall

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,9 @@
 datadog:
-  api_key: aaaaaaaabbbbbbbbccccccccdddddddd
-  site: datadoghq.com
-  python_version: 2
+  config:
+    api_key: aaaaaaaabbbbbbbbccccccccdddddddd
+    site: datadoghq.com
+    python_version: 2
+
   checks:
     process:
       init_config:
@@ -14,3 +16,6 @@ datadog:
         - host: 127.0.0.1
           name: sshd
           port: 22
+
+  install_settings:
+    agent_version: latest

--- a/test/pillar/datadog.sls
+++ b/test/pillar/datadog.sls
@@ -1,9 +1,14 @@
 datadog:
-  api_key: aaaaaaaabbbbbbbbccccccccdddddddd
-  site: datadoghq.com
-  python_version: 2
+  config:
+    api_key: aaaaaaaabbbbbbbbccccccccdddddddd
+    site: datadoghq.com
+    python_version: 2
+
   checks:
     directory:
       instances:
         - directory: "/srv/pillar"
           name: "pillars"
+
+  install_settings:
+    agent_version: latest


### PR DESCRIPTION
## What does this PR do?

Separates the root pillar object `datadog` into two sub-objects:
- `config`, which describes the contents of the `datadog.yaml` config file that will be installed on the minions,
- `install_settings`, which contains various customisable parameters for the Agent install, such as the Agent version.

With this new structure, any arbitrary key can be put in `config`.
For now, what's in config is simply written in the `datadog.yaml` file, but making modifications before writing the file could also be possible in the future (if we want to check fields, for example).

Note: Agent 5 is using a .ini config file, and there's no ini renderer available easily, so we're using the old way with explicitly supported options (except a little cleaner: we're not matching regexes in a file we don't have control of). To comply with what was previously supported on Agent 5 on SaltStack, the `api_key` option is supported for now.

## Motivation

Right now, to add a new option to the config, we need to explicitly add it to the `datadog/config.sls` state file to support it. Moreover, the way we're doing it is not satisfying: we take the file that's present on the minion (which can possibly be anything), and we match regexes to find the option and replace the corresponding line in the file (which can fail if the user manually changed the file).

## Additional Notes

This is a breaking change, as the current pillar structure will not work anymore. 