### PR TITLE
Remove pillar variables not meant to be used

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -29,7 +29,7 @@ datadog_yaml_installed:
 {% for check_name in datadog_checks %}
 datadog_{{ check_name }}_yaml_installed:
   file.managed:
-    - name: {{ datadog_install_settings.checks_confd }}/{{ check_name }}.yaml
+    - name: {{ datadog_install_settings.confd_path }}/{{ check_name }}.yaml
     - source: salt://datadog/files/conf.yaml.jinja
     - user: dd-agent
     - group: root

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -49,7 +49,7 @@ datadog-repo:
 
 datadog-pkg:
   pkg.installed:
-    - name: {{ datadog_install_settings.pkg_name }}
+    - name: datadog-agent
     {%- if latest_agent_version %}
     - version: 'latest'
     {%- elif grains['os_family'].lower() == 'debian' %}

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -11,8 +11,6 @@
         'checks': {},
         'install_settings': {
             'agent_version': 'latest',
-            'pkg_name': 'datadog-agent',
-            'service_name': 'datadog-agent',
         },
 
     }
@@ -35,23 +33,18 @@
     {%- set parsed_version = datadog_install_settings.agent_version | regex_match('(([0-9]+)\.[0-9]+\.[0-9]+)(?:~(rc|beta)\.([0-9]+-[0-9]+))?') %}
 {%- endif %}
 
-
 {# Determine defaults depending on specified version #}
-{% if 'config_folder' not in datadog_install_settings %}
-    {%- if latest_agent_version or parsed_version[1] == '6' %}
-        {% do datadog_install_settings.update({'config_folder': '/etc/datadog-agent'}) %}
-    {%- else %}
-        {% do datadog_install_settings.update({'config_folder': '/etc/dd-agent'}) %}
-    {%- endif %}
-{% endif %}
+{%- if latest_agent_version or parsed_version[1] == '6' %}
+    {% do datadog_install_settings.update({'config_folder': '/etc/datadog-agent'}) %}
+{%- else %}
+    {% do datadog_install_settings.update({'config_folder': '/etc/dd-agent'}) %}
+{%- endif %}
 
-{% if 'config_file' not in datadog_install_settings %}
-    {%- if latest_agent_version or parsed_version[1] == '6' %}
-        {% do datadog_install_settings.update({'config_file': 'datadog.yaml'}) %}
-    {%- else %}
-        {% do datadog_install_settings.update({'config_file': 'datadog.conf'}) %}
-    {%- endif %}
-{% endif %}
+{%- if latest_agent_version or parsed_version[1] == '6' %}
+    {% do datadog_install_settings.update({'config_file': 'datadog.yaml'}) %}
+{%- else %}
+    {% do datadog_install_settings.update({'config_file': 'datadog.conf'}) %}
+{%- endif %}
 
 {% if 'checks_confd' not in datadog_install_settings %}
     {%- if latest_agent_version or parsed_version[1] == '6' %}

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -12,7 +12,6 @@
         'install_settings': {
             'agent_version': 'latest',
         },
-
     }
 }%}
 
@@ -46,10 +45,12 @@
     {% do datadog_install_settings.update({'config_file': 'datadog.conf'}) %}
 {%- endif %}
 
-{% if 'checks_confd' not in datadog_install_settings %}
+{%- if 'confd_path' in datadog_config %}
+    {% do datadog_install_settings.update({'confd_path': datadog_config.confd_path }) %}
+{%- else %}
     {%- if latest_agent_version or parsed_version[1] == '6' %}
-        {% do datadog_install_settings.update({'checks_confd': '/etc/datadog-agent/conf.d'}) %}
+        {% do datadog_install_settings.update({'confd_path': '/etc/datadog-agent/conf.d'}) %}
     {%- else %}
-        {% do datadog_install_settings.update({'checks_confd': '/etc/dd-agent/conf.d'}) %}
+        {% do datadog_install_settings.update({'confd_path': '/etc/dd-agent/conf.d'}) %}
     {%- endif %}
-{% endif %}
+{%- endif %}

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -3,10 +3,10 @@
 
 datadog-agent-service:
   service.running:
-    - name: {{ datadog_install_settings.service_name }}
+    - name: datadog-agent
     - enable: True
     - watch:
-      - pkg: {{ datadog_install_settings.pkg_name }}
+      - pkg: datadog-agent
       - file: {{ config_file_path }}
 {%- if datadog_checks | length %}
       - file: {{ datadog_install_settings.checks_confd }}/*

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -9,5 +9,5 @@ datadog-agent-service:
       - pkg: datadog-agent
       - file: {{ config_file_path }}
 {%- if datadog_checks | length %}
-      - file: {{ datadog_install_settings.checks_confd }}/*
+      - file: {{ datadog_install_settings.confd_path }}/*
 {% endif %}

--- a/datadog/uninstall.sls
+++ b/datadog/uninstall.sls
@@ -2,10 +2,10 @@
 
 datadog-uninstall:
   service.dead:
-    - name: {{ datadog_install_settings.service_name }}
+    - name: datadog-agent
     - enable: False
   pkg.removed:
     - pkgs:
-      - {{ datadog_install_settings.pkg_name }}
+      - datadog-agent
     - require:
       - service: datadog-uninstall


### PR DESCRIPTION
### What does this PR do?

Removes the `pkg_name`, `service_name`, `config_folder` and `config_file` options, as they shouldn't be set by the user.
Removes the `checks_confd` option ; instead, uses the Agent `confd_path` option to get the location where checks configs are located.

### Motivation

Formula cleanup 