### PR TITLE
Add ability to choose integration version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,72 @@ Agent itself and the checks.
 ``datadog.uninstall``
 ------------------
 
-Stops the service and uninstall Datadog Agent.
+Stops the service and uninstalls Datadog Agent.
+
+Pillar configuration
+====================
+
+The formula configuration must be written in the `datadog` key of the pillar file.
+
+The formula configuration contains three parts: ``config``, ``install_settings``, and ``checks``.
+
+``config``
+----------
+The ``config`` option contains the configuration options which will be written in the minions' Agent configuration file (``datadog.yaml`` for Agent 6, ``datadog.conf`` for Agent 5).
+
+Depending on the Agent version installed, different options can be set:
+
+- Agent 6: all options supported by the Agent's configuration file are supported.
+- Agent 5: only the ``api_key`` option is supported.
+
+Example: set the API key, and the site option to ``datadoghq.eu`` (Agent v6 only)
+
+.. code::
+
+  datadog:
+    config:
+      api_key: <your_api_key>
+      site: datadoghq.eu
+
+``install_settings``
+--------------------
+The ``install_settings`` option contains the Agent installation configuration options.
+It has the following option:
+
+- ``agent_version``: the version of the Agent which will be installed.
+
+Example: install the Agent version ``6.14.1``
+
+.. code::
+
+  datadog:
+    install_settings:
+      agent_version: 6.14.1
+
+
+``checks``
+----------
+The ``checks`` option contains configuration for the Agent Checks.
+
+To add an Agent Check, add an entry in the ``checks`` option with the check's name as the key.
+
+Each check has two options:
+
+- ``config``: contains the check's configuration, which will be written to the check's configuration file (``<confd_path>/<check>.d/conf.yaml`` for Agent v6, ``<confd_path>/<check>.yaml`` for Agent v5).
+- ``version``: the version of the check which will be installed (Agent v6 only).
+
+Example: ``directory`` check version ``1.4.0``, monitoring the ``/srv/pillar`` directory
+
+.. code::
+
+  datadog:
+    checks:
+      directory:
+        config:
+          instances:
+            - directory: "/srv/pillar"
+              name: "pillars"
+        version: 1.4.0
 
 Development
 ===========

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Stops the service and uninstalls Datadog Agent.
 Pillar configuration
 ====================
 
-The formula configuration must be written in the `datadog` key of the pillar file.
+The formula configuration must be written in the ``datadog`` key of the pillar file.
 
 The formula configuration contains three parts: ``config``, ``install_settings``, and ``checks``.
 
@@ -72,7 +72,7 @@ Example: set the API key, and the site option to ``datadoghq.eu`` (Agent v6 only
 The ``install_settings`` option contains the Agent installation configuration options.
 It has the following option:
 
-- ``agent_version``: the version of the Agent which will be installed.
+- ``agent_version``: the version of the Agent which will be installed. Default: latest.
 
 Example: install the Agent version ``6.14.1``
 
@@ -92,7 +92,7 @@ To add an Agent Check, add an entry in the ``checks`` option with the check's na
 Each check has two options:
 
 - ``config``: contains the check's configuration, which will be written to the check's configuration file (``<confd_path>/<check>.d/conf.yaml`` for Agent v6, ``<confd_path>/<check>.yaml`` for Agent v5).
-- ``version``: the version of the check which will be installed (Agent v6 only).
+- ``version``: the version of the check which will be installed (Agent v6 only). Default: the version bundled with the agent.
 
 Example: ``directory`` check version ``1.4.0``, monitoring the ``/srv/pillar`` directory
 

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -37,5 +37,14 @@ datadog_{{ check_name }}_yaml_installed:
     - template: jinja
     - context:
         check_name: {{ check_name }}
+
+{%- if latest_agent_version or parsed_version[1] == '6' %}
+{%- if datadog_checks[check_name].version is defined %}
+datadog_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed:
+  cmd.run:
+    - name: sudo -u dd-agent datadog-agent integration install datadog-{{ check_name }}=={{ datadog_checks[check_name].version }}
+{%- endif %}
+{%- endif %}
+
 {% endfor %}
 {% endif %}

--- a/datadog/files/conf.yaml.jinja
+++ b/datadog/files/conf.yaml.jinja
@@ -1,7 +1,11 @@
 {% from "datadog/map.jinja" import datadog_checks with context -%}
 
-{% if datadog_checks[check_name].init_config is not defined -%}
+{% if datadog_checks[check_name].config is defined -%}
+
+{% if datadog_checks[check_name].config.init_config is not defined -%}
 init_config:
 {% endif -%}
 
-{{ datadog_checks[check_name] | yaml(False) }}
+{{ datadog_checks[check_name].config | yaml(False) }}
+
+{% endif -%}

--- a/pillar.example
+++ b/pillar.example
@@ -6,16 +6,18 @@ datadog:
 
   checks:
     process:
-      init_config:
-        procfs_path: /proc
-      instances:
-        - name: ssh
-          search_string: ['sshd']
+      config:
+        init_config:
+          procfs_path: /proc
+        instances:
+          - name: ssh
+            search_string: ['sshd']
     tcp_check:
-      instances:
-        - host: 127.0.0.1
-          name: sshd
-          port: 22
+      config:
+        instances:
+          - host: 127.0.0.1
+            name: sshd
+            port: 22
 
   install_settings:
     agent_version: latest

--- a/test/pillar/datadog.sls
+++ b/test/pillar/datadog.sls
@@ -6,9 +6,10 @@ datadog:
 
   checks:
     directory:
-      instances:
-        - directory: "/srv/pillar"
-          name: "pillars"
+      config:
+        instances:
+          - directory: "/srv/pillar"
+            name: "pillars"
 
   install_settings:
     agent_version: latest


### PR DESCRIPTION
### What does this PR do?

Adds a `version` option for each check configuration, allowing users to choose the check version used. Uses the `datadog-agent integration` command to get and install the chosen version.
Agent 6 only.

The check configuration has been moved under the `config` option of the check.

### Motivation

Support of the `datadog-agent integration` command.

### Additional notes

Breaking change: check config is now in the `config` key of the check's section, instead of being directly in the check's section.

Previously, check configurations had this shape:
```
datadog:
  checks:
    <check_name>:
      <check_config>
```
Now, they're defined this way:
```
datadog:
  checks:
    <check_name>:
      config:
        <check_config>
```