### PR TITLE
[Agent 6] Put check config in <check>.d directory

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -27,9 +27,23 @@ datadog_yaml_installed:
 
 {% if datadog_checks is defined %}
 {% for check_name in datadog_checks %}
+
+{%- if latest_agent_version or parsed_version[1] != '5' %}
+datadog_{{ check_name }}_folder_installed:
+  file.directory:
+    - name: {{ datadog_install_settings.confd_path }}/{{ check_name }}.d
+    - user: dd-agent
+    - group: root
+    - mode: 600
+{%- endif %}
+
 datadog_{{ check_name }}_yaml_installed:
   file.managed:
+    {%- if latest_agent_version or parsed_version[1] != '5' %}
+    - name: {{ datadog_install_settings.confd_path }}/{{ check_name }}.d/conf.yaml
+    {%- else %}
     - name: {{ datadog_install_settings.confd_path }}/{{ check_name }}.yaml
+    {%- endif %}
     - source: salt://datadog/files/conf.yaml.jinja
     - user: dd-agent
     - group: root


### PR DESCRIPTION
### What does this PR do?

If Agent 6 is installed, puts the check config files in their respective `<check>.d` folder.

### Motivation

Check config files were put in the `conf.d` folder directly, which is the standard for Agent 5, but not Agent 6.