### PR TITLE
Add Agent 7 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ To add an Agent Check, add an entry in the ``checks`` option with the check's na
 
 Each check has two options:
 
-- ``config``: contains the check's configuration, which will be written to the check's configuration file (``<confd_path>/<check>.d/conf.yaml`` for Agent v6, ``<confd_path>/<check>.yaml`` for Agent v5).
+- ``config``: contains the check's configuration, which will be written to the check's configuration file (``<confd_path>/<check>.d/conf.yaml`` for Agent v6/v7, ``<confd_path>/<check>.yaml`` for Agent v5).
 - ``version``: the version of the check which will be installed (Agent v6 and v7 only). Default: the version bundled with the agent.
 
 Example: ``directory`` check version ``1.4.0``, monitoring the ``/srv/pillar`` directory

--- a/README.rst
+++ b/README.rst
@@ -51,12 +51,12 @@ The formula configuration contains three parts: ``config``, ``install_settings``
 
 ``config``
 ----------
-The ``config`` option contains the configuration options which will be written in the minions' Agent configuration file (``datadog.yaml`` for Agent 6, ``datadog.conf`` for Agent 5).
+The ``config`` option contains the configuration options which will be written in the minions' Agent configuration file (``datadog.yaml`` for Agent v6, ``datadog.conf`` for Agent v5).
 
 Depending on the Agent version installed, different options can be set:
 
-- Agent 6: all options supported by the Agent's configuration file are supported.
-- Agent 5: only the ``api_key`` option is supported.
+- Agent v6 & v7: all options supported by the Agent's configuration file are supported.
+- Agent v5: only the ``api_key`` option is supported.
 
 Example: set the API key, and the site option to ``datadoghq.eu`` (Agent v6 only)
 
@@ -72,7 +72,7 @@ Example: set the API key, and the site option to ``datadoghq.eu`` (Agent v6 only
 The ``install_settings`` option contains the Agent installation configuration options.
 It has the following option:
 
-- ``agent_version``: the version of the Agent which will be installed. Default: latest.
+- ``agent_version``: the version of the Agent which will be installed. Default: latest (will install the latest Agent v7 package).
 
 Example: install the Agent version ``6.14.1``
 
@@ -92,7 +92,7 @@ To add an Agent Check, add an entry in the ``checks`` option with the check's na
 Each check has two options:
 
 - ``config``: contains the check's configuration, which will be written to the check's configuration file (``<confd_path>/<check>.d/conf.yaml`` for Agent v6, ``<confd_path>/<check>.yaml`` for Agent v5).
-- ``version``: the version of the check which will be installed (Agent v6 only). Default: the version bundled with the agent.
+- ``version``: the version of the check which will be installed (Agent v6 and v7 only). Default: the version bundled with the agent.
 
 Example: ``directory`` check version ``1.4.0``, monitoring the ``/srv/pillar`` directory
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ The formula configuration contains three parts: ``config``, ``install_settings``
 
 ``config``
 ----------
-The ``config`` option contains the configuration options which will be written in the minions' Agent configuration file (``datadog.yaml`` for Agent v6, ``datadog.conf`` for Agent v5).
+The ``config`` option contains the configuration options which will be written in the minions' Agent configuration file (``datadog.yaml`` for Agent v6 & v7, ``datadog.conf`` for Agent v5).
 
 Depending on the Agent version installed, different options can be set:
 

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -38,7 +38,7 @@ datadog_{{ check_name }}_yaml_installed:
     - context:
         check_name: {{ check_name }}
 
-{%- if latest_agent_version or parsed_version[1] == '6' %}
+{%- if latest_agent_version or parsed_version[1] != '5' %}
 {%- if datadog_checks[check_name].version is defined %}
 datadog_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed:
   cmd.run:

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -17,7 +17,9 @@ datadog-repo:
             {% set distribution = 'stable' %}
         {%- endif %}
         {#- Determine which channel we should look in #}
-        {%- if latest_agent_version or parsed_version[1] == '6' %}
+        {%- if latest_agent_version or parsed_version[1] == '7' %}
+            {% set packages = '7' %}
+        {%- elif parsed_version[1] == '6' %}
             {% set packages = '6' %}
         {%- else %}
             {% set packages = 'main' %}
@@ -35,7 +37,9 @@ datadog-repo:
         {#- Determine the location of the package we want #}
         {%- if not latest_agent_version and (parsed_version[2] == 'beta' or parsed_version[2] == 'rc') %}
             {% set path = 'beta' %}
-        {%- elif latest_agent_version or parsed_version[1] == '6' %}
+        {%- elif latest_agent_version or parsed_version[1] == '7' %}
+            {% set path = 'stable/7' %}
+        {%- elif parsed_version[1] == '6' %}
             {% set path = 'stable/6' %}
         {%- else %}
             {% set path = 'rpm' %}

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -33,13 +33,13 @@
 {%- endif %}
 
 {# Determine defaults depending on specified version #}
-{%- if latest_agent_version or parsed_version[1] == '6' %}
+{%- if latest_agent_version or parsed_version[1] != '5' %}
     {% do datadog_install_settings.update({'config_folder': '/etc/datadog-agent'}) %}
 {%- else %}
     {% do datadog_install_settings.update({'config_folder': '/etc/dd-agent'}) %}
 {%- endif %}
 
-{%- if latest_agent_version or parsed_version[1] == '6' %}
+{%- if latest_agent_version or parsed_version[1] != '5' %}
     {% do datadog_install_settings.update({'config_file': 'datadog.yaml'}) %}
 {%- else %}
     {% do datadog_install_settings.update({'config_file': 'datadog.conf'}) %}
@@ -48,7 +48,7 @@
 {%- if 'confd_path' in datadog_config %}
     {% do datadog_install_settings.update({'confd_path': datadog_config.confd_path }) %}
 {%- else %}
-    {%- if latest_agent_version or parsed_version[1] == '6' %}
+    {%- if latest_agent_version or parsed_version[1] != '5' %}
         {% do datadog_install_settings.update({'confd_path': '/etc/datadog-agent/conf.d'}) %}
     {%- else %}
         {% do datadog_install_settings.update({'confd_path': '/etc/dd-agent/conf.d'}) %}


### PR DESCRIPTION
### What does this PR do?

Changes the formula to support the Agent v7 distribution channels (apt & yum repositories).
`latest` will now point to the latest package in the `7` channel.
Updates documentation to include v7.

### Motivation

Add support for the upcoming Agent v7.