### PR TITLE
Fix Agent 6 & 7 install from beta repositories

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -36,7 +36,13 @@ datadog-repo:
     {%- elif grains['os_family'].lower() == 'redhat' %}
         {#- Determine the location of the package we want #}
         {%- if not latest_agent_version and (parsed_version[2] == 'beta' or parsed_version[2] == 'rc') %}
-            {% set path = 'beta' %}
+            {%- if parsed_version[1] == '7' %}
+                {% set path = 'beta/7' %}
+            {%- elif parsed_version[1] == '6' %}
+                {% set path = 'beta/6' %}
+            {%- else %}
+                {% set path = 'beta' %}
+            {%- endif %}
         {%- elif latest_agent_version or parsed_version[1] == '7' %}
             {% set path = 'stable/7' %}
         {%- elif parsed_version[1] == '6' %}

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -29,7 +29,7 @@
     {%- set latest_agent_version = true %}
 {%- else %}
     {%- set latest_agent_version = false %}
-    {%- set parsed_version = datadog_install_settings.agent_version | regex_match('(([0-9]+)\.[0-9]+\.[0-9]+)(?:~(rc|beta)\.([0-9]+-[0-9]+))?') %}
+    {%- set parsed_version = datadog_install_settings.agent_version | regex_match('(([0-9]+)\.[0-9]+\.[0-9]+)(?:~(rc|beta)\.([0-9]+))?') %}
 {%- endif %}
 
 {# Determine defaults depending on specified version #}


### PR DESCRIPTION
### What does this PR do?

Fixes the yum repository path for beta installs (Agent 6 betas are in `beta/6`, Agent 7 betas in `beta/7`).
Fixes the regex which checks if a beta version will be installed (there was a `-[0-9]+` too much at the end of the regex). The previous regex would match `7.15.0~beta.1-1` and not `7.15.0~beta.1`, which makes the install fail since we add the `-1` again during the installation (giving `7.15.0~beta.1-1-1`, which is not an existing version).

### Motivation

Agent 7 testing.
