### PR TITLE
Fix checks config directory permissions

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -34,7 +34,7 @@ datadog_{{ check_name }}_folder_installed:
     - name: {{ datadog_install_settings.confd_path }}/{{ check_name }}.d
     - user: dd-agent
     - group: root
-    - mode: 600
+    - mode: 700
 {%- endif %}
 
 datadog_{{ check_name }}_yaml_installed:


### PR DESCRIPTION
### What does this PR do?

Fixes the permissions of the `<check>.d` directory: `700` instead of `600`.