### PR TITLE
Create install info file

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -68,3 +68,15 @@ datadog_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_instal
 
 {% endfor %}
 {% endif %}
+
+{% set install_info_path = '%s/install_info'|format(datadog_install_settings.config_folder) -%}
+install_info_installed:
+  file.managed:
+    - name: {{ install_info_path }}
+    - source: salt://datadog/files/install_info.jinja
+    - user: dd-agent
+    - group: dd-agent
+    - mode: 600
+    - template: jinja
+    - require:
+      - pkg: datadog-pkg

--- a/datadog/files/install_info.jinja
+++ b/datadog/files/install_info.jinja
@@ -1,0 +1,6 @@
+{% from "datadog/map.jinja" import formula_version -%}
+---
+install_method:
+  tool: saltstack
+  tool_version: saltstack-{{ salt.get('salt_version', 'unknown') }}
+  installer_version: datadog_formula-{{ formula_version  }}

--- a/datadog/files/install_info.jinja
+++ b/datadog/files/install_info.jinja
@@ -2,5 +2,5 @@
 ---
 install_method:
   tool: saltstack
-  tool_version: saltstack-{{ salt.get('salt_version', 'unknown') }}
+  tool_version: saltstack-{{ salt['test.version']() if 'test.version' in salt else 'unknown' }}
   installer_version: datadog_formula-{{ formula_version  }}

--- a/datadog/files/install_info.jinja
+++ b/datadog/files/install_info.jinja
@@ -3,4 +3,4 @@
 install_method:
   tool: saltstack
   tool_version: saltstack-{{ salt['test.version']() if 'test.version' in salt else 'unknown' }}
-  installer_version: datadog_formula-{{ formula_version  }}
+  installer_version: datadog_formula-{{ formula_version }}

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -1,3 +1,5 @@
+{% set formula_version = '3.0' %}
+
 {% set os_family_map = salt['grains.filter_by']({
       'Debian': {},
       'RedHat': {},

--- a/test/utils/check_apt_install.py
+++ b/test/utils/check_apt_install.py
@@ -41,10 +41,10 @@ def main(argv):
       print("install_info check successful!")
       sys.exit()
     else:
-      print("install_info check failed")
+      print("install_info check failed.")
       sys.exit(1)
   else:
-    print("Skipping install_info check")
+    print("Skipping install_info check.")
     sys.exit()
 
 

--- a/test/utils/check_apt_install.py
+++ b/test/utils/check_apt_install.py
@@ -39,13 +39,13 @@ def main(argv):
   if expected_major_version:
     if check_install_info(expected_major_version):
       print("install_info check successful!")
-      sys.exit()
     else:
       print("install_info check failed.")
       sys.exit(1)
   else:
     print("Skipping install_info check.")
-    sys.exit()
+
+  sys.exit()
 
 
 if __name__ == "__main__":

--- a/test/utils/check_apt_install.py
+++ b/test/utils/check_apt_install.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import apt, re, sys
-from helpers import get_options, check_major_version
+from helpers import get_options, check_major_version, check_install_info
 
 def get_apt_package_version(package_name):
   cache = apt.cache.Cache()
@@ -31,10 +31,22 @@ def main(argv):
   result = check_major_version(installed_version, expected_major_version)
   if result:
     print("Agent version check successful!")
-    sys.exit()
   else:
     print("Agent version check failed.")
     sys.exit(1)
+
+  # expected_major_version
+  if expected_major_version:
+    if check_install_info(expected_major_version):
+      print("install_info check successful!")
+      sys.exit()
+    else:
+      print("install_info check failed")
+      sys.exit(1)
+  else:
+    print("Skipping install_info check")
+    sys.exit()
+
 
 if __name__ == "__main__":
   main(sys.argv)

--- a/test/utils/check_yum_install.py
+++ b/test/utils/check_yum_install.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import yum, sys
-from helpers import get_options, check_major_version
+from helpers import get_options, check_major_version, check_install_info
 
 def get_yum_package_version(package_name):
   yb = yum.YumBase()
@@ -25,10 +25,22 @@ def main(argv):
   result = check_major_version(installed_version, expected_major_version)
   if result:
     print("Agent version check successful!")
-    sys.exit()
   else:
     print("Agent version check failed.")
     sys.exit(1)
+
+  # expected_major_version
+  if expected_major_version:
+    if check_install_info(expected_major_version):
+      print("install_info check successful!")
+      sys.exit()
+    else:
+      print("install_info check failed")
+      sys.exit(1)
+  else:
+    print("Skipping install_info check")
+    sys.exit()
+
 
 if __name__ == "__main__":
   main(sys.argv)

--- a/test/utils/check_yum_install.py
+++ b/test/utils/check_yum_install.py
@@ -15,6 +15,7 @@ def get_yum_package_version(package_name):
   
   return installed_version
 
+
 def main(argv):
   expected_major_version = get_options(argv[1:])
   print("Expected major version: {}".format(expected_major_version))
@@ -33,13 +34,13 @@ def main(argv):
   if expected_major_version:
     if check_install_info(expected_major_version):
       print("install_info check successful!")
-      sys.exit()
     else:
       print("install_info check failed.")
       sys.exit(1)
   else:
     print("Skipping install_info check.")
-    sys.exit()
+
+  sys.exit()
 
 
 if __name__ == "__main__":

--- a/test/utils/check_yum_install.py
+++ b/test/utils/check_yum_install.py
@@ -35,10 +35,10 @@ def main(argv):
       print("install_info check successful!")
       sys.exit()
     else:
-      print("install_info check failed")
+      print("install_info check failed.")
       sys.exit(1)
   else:
-    print("Skipping install_info check")
+    print("Skipping install_info check.")
     sys.exit()
 
 

--- a/test/utils/helpers.py
+++ b/test/utils/helpers.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-import getopt, re
+import getopt
+import re
+import os.path
+import os
 
 def get_options(args):
   expected_major_version = None
@@ -28,3 +31,33 @@ def check_major_version(installed_version, expected_major_version):
 
   print("Installed Agent major version: {}".format(installed_major_version))
   return installed_major_version == expected_major_version
+
+def get_config_dir(agent_version):
+  """Get the agent configuration directory on *nix systems."""
+  if int(agent_version) == 5:
+    return "/etc/dd-agent"
+  else:
+    return "/etc/datadog-agent"
+
+
+def check_install_info(agent_version):
+  """Check install_info file."""
+  config_dir = get_config_dir(agent_version)
+  info_path = os.path.join(config_dir, "install_info")
+
+  if not os.path.isfile(info_path):
+    print("install_info file not found at {}".format(info_path))
+    return False
+
+  with open(info_path, 'r') as install_info:
+    contents = install_info.read()
+    for pat in [
+      r'^  tool:\s*saltstack$',
+      r'^  tool_version:\s*saltstack-([0-9.]+|unknown)$',
+      r'^  installer_version:\s*datadog_formula-[0-9](\.[0-9]+)*$'
+    ]:
+      if not re.search(pat, contents, flags=re.MULTILINE):
+        print("Expected match for '{}' in '{}'".format(pat, contents))
+        return False
+
+  return True


### PR DESCRIPTION
### What does this PR do?

Creates `install_info` file with information about the install method used (overwrites any other existing file).

### Additional information

- The formula version is managed by git tags. I decided to hardcode the version in a variable because: (i) there is no guarantee that the user will clone the repo instead of, e. g., downloading the contents as a ZIP and (ii) there seems to be no way to run commands on the master (which is the one which could access this information anyway).
- The saltstack version provided by the `install_info` file is the one on the specific minion where it is being installed.

### Describe your test plan

I added tests to the pipeline to check the install_info file is created with the correct information.