### PR TITLE
Addition of logs check section for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The example below installs Agent v6.14.1:
       agent_version: 6.14.1
 ```
 
-#### Integrations
+#### Checks
 
 To add an Agent integration to your host, use the `checks` variable with the check's name as the key. Each check has two options:
 
@@ -145,6 +145,27 @@ datadog:
             name: "pillars"
       version: 1.4.0
 ```
+
+##### Logs
+
+To output logs, use the `logs` key to indicate you want to create a check named `logs`. Note that there is no specific restriction on the name of this check. You can name it `system_logs`, for instance, and log collection will still occur. This check will automatically create the `/etc/datadog-agent/conf.d/logs.d` directory.
+
+Below is an example configuration of a `logs` check with a `config` key:
+
+```text
+  checks:
+    logs:
+      config:
+        logs:
+          - type: file
+            path: "/var/log/syslog"
+            service: "system"
+          - type: file
+            path: "/var/log/auth.log"
+            service: "system"
+```
+
+You can use the config key of the this check to indicate the contents of `/etc/datadog-agent/conf.d/logs.d/conf.yaml`. This is where you put your config file contents. In the case of this example, the config file itself contains the `logs` key, which is why you have both an inner and an outer `logs` key if you also name your check "logs".
 
 ## States
 

--- a/README.md
+++ b/README.md
@@ -148,13 +148,19 @@ datadog:
 
 ##### Logs
 
-To output logs, use the `logs` key to indicate you want to create a check named `logs`. Note that there is no specific restriction on the name of this check. You can name it `system_logs`, for instance, and log collection will still occur. This check will automatically create the `/etc/datadog-agent/conf.d/logs.d` directory.
+To send logs to Datadog, use the `logs` key in a check (either an existing check to setup logs for an integration, or a custom check to setup custom log collection). In the following example, we'll use a custom check named `system_logs`.
 
-Below is an example configuration of a `logs` check with a `config` key:
+The contents of the `config:` key of this check will be written to the `/etc/datadog-agent/conf.d/<check_name>.d/conf.yaml` file (in this example: `/etc/datadog-agent/conf.d/system_logs.d/conf.yaml`).
+
+To list the logs you want to collect, fill the `config` section the same way you'd fill the `conf.yaml` file of a custom log collection configuration file (refer to the section on [custom log collection](https://docs.datadoghq.com/agent/logs/?tab=tailfiles#custom-log-collection) in the official docs).
+
+For instance, to collect logs from `/var/log/syslog` and `/var/log/auth.log`, the configuration would be:
 
 ```text
+datadog:
+[...]
   checks:
-    logs:
+    system_logs:
       config:
         logs:
           - type: file
@@ -165,7 +171,6 @@ Below is an example configuration of a `logs` check with a `config` key:
             service: "system"
 ```
 
-You can use the config key of the this check to indicate the contents of `/etc/datadog-agent/conf.d/logs.d/conf.yaml`. This is where you put your config file contents. In the case of this example, the config file itself contains the `logs` key, which is why you have both an inner and an outer `logs` key if you also name your check "logs".
 
 ## States
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ datadog:
 
 ##### Logs
 
+To enable log collection, set `logs_enabled` to `true` in the main configuration:
+```text
+datadog:
+  config:
+    logs_enabled: true```
+
 To send logs to Datadog, use the `logs` key in a check (either an existing check to setup logs for an integration, or a custom check to setup custom log collection). In the following example, we'll use a custom check named `system_logs`.
 
 The contents of the `config:` key of this check will be written to the `/etc/datadog-agent/conf.d/<check_name>.d/conf.yaml` file (in this example: `/etc/datadog-agent/conf.d/system_logs.d/conf.yaml`).

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ To enable log collection, set `logs_enabled` to `true` in the main configuration
 ```text
 datadog:
   config:
-    logs_enabled: true```
+    logs_enabled: true
+```
 
 To send logs to Datadog, use the `logs` key in a check (either an existing check to setup logs for an integration, or a custom check to setup custom log collection). In the following example, we'll use a custom check named `system_logs`.
 


### PR DESCRIPTION
### What does this PR do?
- Adds a checks section dedicated to logs
- Renames "integrations" section to checks as the Configuration intro section currently says `it contains three parts: config, install_settings, and checks.` and we're adding add't checks for logs.

### Motivation
Jira request for documentation