### PR TITLE
 Allow installing third-party integrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
 
   setup_ubuntu:
     steps:
-      - run: apt-get update && apt-get install -y curl
+      - run: apt-get update && apt-get install -y curl sudo
       - run: cp test/utils/systemctl.py /bin/systemctl
       - run: cp test/utils/systemctl.py /bin/systemd
       - setup_common
@@ -27,7 +27,7 @@ commands:
   setup_centos:
     steps:
       - run: yum -y update
-      - run: yum install -y curl
+      - run: yum install -y curl sudo
       - run: cp test/utils/systemctl.py /usr/bin/systemctl
       - run: cp test/utils/systemctl.py /usr/bin/systemd
       - setup_common

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To add an Agent integration to your host, use the `checks` variable with the che
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `config`  | Add the configuration options to write to the check's configuration file:<br>Agent v6 & v7: `<confd_path>/<check>.d/conf.yaml`<br>Agent v5: `<confd_path>/<check>.yaml` |
 | `version` | For Agent v6 & v7, the version of the check to install (defaults to the version bundled with the Agent).                                                                |
-| `third_party` | For Agent v6 & v7 (versions 6/7.22.0 and higher only), boolean to indicate that the integration to install is a third-party integration. Must be paired with the `version` option.                                                                |
+| `third_party` | For Agent v6 & v7 (versions v6.21.0/v7.21.0 and higher only), boolean to indicate that the integration to install is a third-party integration. Must be paired with the `version` option.                                                                |
 
 Below is an example to use v1.4.0 of the [Directory][3] integration monitoring the `/srv/pillar` directory:
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ To add an Agent integration to your host, use the `checks` variable with the che
 |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `config`  | Add the configuration options to write to the check's configuration file:<br>Agent v6 & v7: `<confd_path>/<check>.d/conf.yaml`<br>Agent v5: `<confd_path>/<check>.yaml` |
 | `version` | For Agent v6 & v7, the version of the check to install (defaults to the version bundled with the Agent).                                                                |
+| `third_party` | For Agent v6 & v7 (versions 6/7.22.0 and higher only), boolean to indicate that the integration to install is a third-party integration. Must be paired with the `version` option.                                                                |
 
 Below is an example to use v1.4.0 of the [Directory][3] integration monitoring the `/srv/pillar` directory:
 
@@ -144,6 +145,23 @@ datadog:
           - directory: "/srv/pillar"
             name: "pillars"
       version: 1.4.0
+```
+
+Below is an example to use v1.0.0 of a sample third-party integration named "third-party-integration":
+
+```
+datadog:
+  config:
+    api_key: <YOUR_DD_API_KEY>
+  install_settings:
+    agent_version: <AGENT7_VERSION>
+  checks:
+    third-party-integration:
+      config:
+        instances:
+          - some_config: "some value"
+      version: 1.0.0
+      third_party: true
 ```
 
 ##### Logs

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -60,9 +60,16 @@ datadog_{{ check_name }}_yaml_installed:
 
 {%- if latest_agent_version or parsed_version[1] != '5' %}
 {%- if datadog_checks[check_name].version is defined %}
+
+{%- if datadog_checks[check_name].third_party is defined and datadog_checks[check_name].third_party %}
+{% set install_command = "install --third-party" %}
+{%- else %}
+{% set install_command = "install" %}
+{%- endif %}
+
 datadog_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed:
   cmd.run:
-    - name: sudo -u dd-agent datadog-agent integration install datadog-{{ check_name }}=={{ datadog_checks[check_name].version }}
+    - name: sudo -u dd-agent datadog-agent integration {{ install_command }} datadog-{{ check_name }}=={{ datadog_checks[check_name].version }}
 {%- endif %}
 {%- endif %}
 

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -61,7 +61,7 @@ datadog_{{ check_name }}_yaml_installed:
 {%- if latest_agent_version or parsed_version[1] != '5' %}
 {%- if datadog_checks[check_name].version is defined %}
 
-{%- if datadog_checks[check_name].third_party is defined and datadog_checks[check_name].third_party %}
+{%- if datadog_checks[check_name].third_party is defined and datadog_checks[check_name].third_party == true %}
 {% set install_command = "install --third-party" %}
 {%- else %}
 {% set install_command = "install" %}

--- a/test/pillar/datadog6.sls
+++ b/test/pillar/datadog6.sls
@@ -10,6 +10,13 @@ datadog:
         instances:
           - directory: "/srv/pillar"
             name: "pillars"
+    # Test installing a third-party integration
+    bind9:
+      config:
+        instances:
+          - {}
+      version: 0.1.0
+      third_party: true
 
   install_settings:
-    agent_version: 6.16.0
+    agent_version: 6.21.1

--- a/test/pillar/datadog7.sls
+++ b/test/pillar/datadog7.sls
@@ -9,6 +9,13 @@ datadog:
         instances:
           - directory: "/srv/pillar"
             name: "pillars"
+    # Test installing a third-party integration
+    bind9:
+      config:
+        instances:
+          - {}
+      version: 0.1.0
+      third_party: true
 
   install_settings:
     agent_version: latest


### PR DESCRIPTION
### What does this PR do?

Adds a `third_party` option to the checks config to specify that the check to install is a third-party check (defined in https://github.com/DataDog/integrations-extras).

### Motivation

Installing third-party integrations is supported since Agent 6.21.0/7.21.0.

