### PR TITLE
Restart the datadog-agent service after an integration install

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -70,6 +70,7 @@ datadog_{{ check_name }}_yaml_installed:
 datadog_check_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed:
   cmd.run:
     - name: sudo -u dd-agent datadog-agent integration {{ install_command }} datadog-{{ check_name }}=={{ datadog_checks[check_name].version }}
+    - unless: sudo -u dd-agent datadog-agent integration freeze | grep datadog-{{ check_name }}=={{ datadog_checks[check_name].version }}
 {%- endif %}
 {%- endif %}
 

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -67,7 +67,7 @@ datadog_{{ check_name }}_yaml_installed:
 {% set install_command = "install" %}
 {%- endif %}
 
-datadog_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed:
+datadog_check_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed:
   cmd.run:
     - name: sudo -u dd-agent datadog-agent integration {{ install_command }} datadog-{{ check_name }}=={{ datadog_checks[check_name].version }}
 {%- endif %}

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_install_settings, datadog_checks with context %}
+{% from "datadog/map.jinja" import datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
 {% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
 datadog-agent-service:
@@ -7,8 +7,16 @@ datadog-agent-service:
     - enable: True
     - watch:
       - pkg: datadog-agent
-      - cmd: datadog_check_*_version_*_installed
       - file: {{ config_file_path }}
 {%- if datadog_checks | length %}
       - file: {{ datadog_install_settings.confd_path }}/*
+{% endif %}
+{%- if latest_agent_version or parsed_version[1] != '5' %}
+{%- if datadog_checks is defined %}
+{%- for check_name in datadog_checks %}
+{%- if datadog_checks[check_name].version is defined %}
+      - cmd: datadog_check_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_installed
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endif %}

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -7,6 +7,7 @@ datadog-agent-service:
     - enable: True
     - watch:
       - pkg: datadog-agent
+      - cmd: datadog_check_*_version_*_installed
       - file: {{ config_file_path }}
 {%- if datadog_checks | length %}
       - file: {{ datadog_install_settings.confd_path }}/*


### PR DESCRIPTION
### What does this PR do?

Only try to install integration if the targeted version is not already installed (to make the formula idempotent).
Watch integration installs: restart the datadog-agent service when at least one integration install happens.

### Motivation

Make formula idempotent.
Correctly restart the Agent on integration installs (it was only restarting on config file changes before).

### Additional notes

The service watch list generation has become a bit heavy with all the added conditions, but they're necessary to make sure we don't try to match states that do not exist (which makes the formula fail).
