### PR TITLE
Add the 'CURRENT' public key entry, get keys from keys.datadoghq.com

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -61,9 +61,9 @@ datadog-repo:
     - baseurl: https://yum.datadoghq.com/{{ path }}/{{ grains['cpuarch'] }}
     - gpgcheck: '1'
     {%- if latest_agent_version or parsed_version[1] == '7' %}
-    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+    - gpgkey: https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     {%- else %}
-    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    - gpgkey: https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     {%- endif %}
     - sslverify: '1'
     {% endif %}

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -61,9 +61,9 @@ datadog-repo:
     - baseurl: https://yum.datadoghq.com/{{ path }}/{{ grains['cpuarch'] }}
     - gpgcheck: '1'
     {%- if latest_agent_version or parsed_version[1] == '7' %}
-    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     {%- else %}
-    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+    - gpgkey: https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY.public
     {%- endif %}
     - sslverify: '1'
     {% endif %}


### PR DESCRIPTION
### What does this PR do?

The special DATADOG_RPM_KEY_CURRENT.public entry will always contain the key that is used to sign current metadata as well as newly released packages.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
