### PR TITLE
Enable repo_gpgcheck for Agent > 5 repos

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -57,6 +57,11 @@ datadog-repo:
         {%- else %}
             {% set path = 'rpm' %}
         {%- endif %}
+    {%- if latest_agent_version or parsed_version[1] != '5' %}
+    - repo_gpgcheck: '1'
+    {%- else %}
+    - repo_gpgcheck: '0'
+    {%- endif %}
     - name: datadog
     - baseurl: https://yum.datadoghq.com/{{ path }}/{{ grains['cpuarch'] }}
     - gpgcheck: '1'


### PR DESCRIPTION
### What does this PR do?

Enables `repo_gpgcheck` for yum repos (except Agent 5, where we don't sign repodata).

### Motivation

Enhanced security by verifying repodata signatures.

### Additional Notes



### Describe your test plan

Ensure that packages of Agent 6/7 can still be installed on RH distros.
