### PR TITLE
Implement improvements to APT keys management

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -20,9 +20,9 @@ key-file-{{ key_fingerprint }}-import:
         echo "${KEY_FROM_URL}" | gpg --import --batch --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }}
     - env:
         KEY_FROM_URL: |
-          {{ key_response.body| indent(10) }}
+          {{ key_response.body | indent(10) }}
     - unless: |
-        echo "{{ key_response.body|indent(8) }}
+        echo "{{ key_response.body | indent(8) }}
         " | gpg --dry-run --import --batch --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }} 2>&1 | grep "unchanged: 1"
 {% endmacro %}
 

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -1,62 +1,114 @@
-{% from "datadog/map.jinja" import datadog_install_settings, latest_agent_version, parsed_version with context %}
+{% from "datadog/map.jinja" import
+    datadog_apt_default_keys,
+    datadog_apt_trusted_d_keyring,
+    datadog_apt_usr_share_keyring,
+    datadog_install_settings,
+    latest_agent_version,
+    parsed_version
+  with context %}
+
+{% macro import_apt_key(key_fingerprint, key_url) %}
+{# Since we always have to download at least the CURRENT key, but can't tell Saltstack to not
+   count it as "changed state", we do this workaround with fetching a URL and setting it
+   to a variable, which doesn't show up in state at all. #}
+{% set key_response = salt['http.query'](key_url) %}
+
+key-file-{{ key_fingerprint }}-import:
+  cmd.run:
+    {# we put key inside an env variable here to prevent the whole long key from appearing in the state output #}
+    - name: |
+        echo "${KEY_FROM_URL}" | gpg --import --batch --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }}
+    - env:
+        KEY_FROM_URL: |
+          {{ key_response.body| indent(10) }}
+    - unless: |
+        echo "{{ key_response.body|indent(8) }}" | gpg --dry-run --import --batch --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }} 2>&1 | grep "unchanged: 1"
+{% endmacro %}
 
 {%- if grains['os_family'].lower() == 'debian' %}
 datadog-apt-https:
   pkg.installed:
     - name: apt-transport-https
 
-datadog-apt-key:
+{# Create the keyring unless it exists #}
+{{ datadog_apt_usr_share_keyring }}:
+  file.managed:
+    - contents: ''
+    - contents_newline: False
+    - mode: 0644
+    - unless: ls {{ datadog_apt_usr_share_keyring }}
+
+{% set apt_keys_tmpdir = salt['temp.dir']() %}
+
+{% for key_fingerprint, key_url in datadog_apt_default_keys.items() %}
+  {{ import_apt_key(key_fingerprint, key_url) }}
+{% endfor %}
+
+{% if (grains['os'].lower() == 'ubuntu' and grains['osrelease'].split('.')[0]|int < 16) or
+      (grains['os'].lower() == 'debian' and grains['osrelease'].split('.')[0]|int < 9) %}
+{{ datadog_apt_trusted_d_keyring }}:
+  file.managed:
+    - mode: 0644
+    - source: {{ datadog_apt_usr_share_keyring }}
+{% endif %}
+
+{% endif %}
+
+{# Some versions of Salt still in use have issue with providing repo options for
+   APT sources: https://github.com/saltstack/salt/issues/22412; therefore we use
+   file.managed instead of pkgrepo.managed for debian platforms #}
+
+{%- if grains['os_family'].lower() == 'debian' -%}
+datadog-repo:
+  file.managed:
+    {# Determine beta or stable distribution from version #}
+    {% if not latest_agent_version and (parsed_version[2] == 'beta' or parsed_version[2] == 'rc') %}
+        {% set distribution = 'beta' %}
+    {% else %}
+        {% set distribution = 'stable' %}
+    {% endif %}
+    {# Determine which channel we should look in #}
+    {% if latest_agent_version or parsed_version[1] == '7' %}
+        {% set packages = '7' %}
+    {% elif parsed_version[1] == '6' %}
+        {% set packages = '6' %}
+    {% else %}
+        {% set packages = 'main' %}
+    {% endif %}
+    - contents: deb [signed-by={{ datadog_apt_usr_share_keyring }}] https://apt.datadoghq.com/ {{ distribution }} {{ packages }}
+    - mode: 0644
+    - name: /etc/apt/sources.list.d/datadog.list
+    - require:
+      - pkg: datadog-apt-https
+
+datadog-repo-refresh:
   cmd.run:
-    - name: apt-key adv --recv-keys --keyserver 'keyserver.ubuntu.com' D75CEA17048B9ACBF186794B32637D44F14F620E
-    - unless: apt-key list | grep 'D75C EA17 048B 9ACB F186  794B 3263 7D44 F14F 620E' || apt-key list | grep 'D75CEA17048B9ACBF186794B32637D44F14F620E'
-{%- endif %}
+    - name: apt-get update
+    - retry:
+        attempts: 2 # TODO: 5
+        interval: 1
+
+{%- elif grains['os_family'].lower() == 'redhat' %}
 
 datadog-repo:
   pkgrepo.managed:
     - humanname: "Datadog, Inc."
-    {%- if grains['os_family'].lower() == 'debian' -%}
-        {#- Determine beta or stable distribution from version #}
-        {%- if not latest_agent_version and (parsed_version[2] == 'beta' or parsed_version[2] == 'rc') %}
-            {% set distribution = 'beta' %}
-        {%- else %}
-            {% set distribution = 'stable' %}
-        {%- endif %}
-        {#- Determine which channel we should look in #}
-        {%- if latest_agent_version or parsed_version[1] == '7' %}
-            {% set packages = '7' %}
-        {%- elif parsed_version[1] == '6' %}
-            {% set packages = '6' %}
-        {%- else %}
-            {% set packages = 'main' %}
-        {%- endif %}
-    - name: deb https://apt.datadoghq.com/ {{ distribution }} {{ packages }}
-    - keyserver: keyserver.ubuntu.com
-    - keyid:
-      - A2923DFF56EDA6E76E55E492D3A80E30382E94DE
-      - D75CEA17048B9ACBF186794B32637D44F14F620E
-    - file: /etc/apt/sources.list.d/datadog.list
-    - require:
-      - pkg: datadog-apt-https
-    - retry:
-      - attempts: 5
-      - interval: 1
-    {%- elif grains['os_family'].lower() == 'redhat' %}
-        {#- Determine the location of the package we want #}
-        {%- if not latest_agent_version and (parsed_version[2] == 'beta' or parsed_version[2] == 'rc') %}
-            {%- if parsed_version[1] == '7' %}
-                {% set path = 'beta/7' %}
-            {%- elif parsed_version[1] == '6' %}
-                {% set path = 'beta/6' %}
-            {%- else %}
-                {% set path = 'beta' %}
-            {%- endif %}
-        {%- elif latest_agent_version or parsed_version[1] == '7' %}
-            {% set path = 'stable/7' %}
-        {%- elif parsed_version[1] == '6' %}
-            {% set path = 'stable/6' %}
-        {%- else %}
-            {% set path = 'rpm' %}
-        {%- endif %}
+      {#- Determine the location of the package we want #}
+      {%- if not latest_agent_version and (parsed_version[2] == 'beta' or parsed_version[2] == 'rc') %}
+          {%- if parsed_version[1] == '7' %}
+              {% set path = 'beta/7' %}
+          {%- elif parsed_version[1] == '6' %}
+              {% set path = 'beta/6' %}
+          {%- else %}
+              {% set path = 'beta' %}
+          {%- endif %}
+      {%- elif latest_agent_version or parsed_version[1] == '7' %}
+          {% set path = 'stable/7' %}
+      {%- elif parsed_version[1] == '6' %}
+          {% set path = 'stable/6' %}
+      {%- else %}
+          {% set path = 'rpm' %}
+      {%- endif %}
     {%- if latest_agent_version or parsed_version[1] != '5' %}
     - repo_gpgcheck: '1'
     {%- else %}
@@ -71,7 +123,8 @@ datadog-repo:
     - gpgkey: https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     {%- endif %}
     - sslverify: '1'
-    {% endif %}
+
+{% endif %}
 
 datadog-pkg:
   pkg.installed:

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -22,7 +22,8 @@ key-file-{{ key_fingerprint }}-import:
         KEY_FROM_URL: |
           {{ key_response.body| indent(10) }}
     - unless: |
-        echo "{{ key_response.body|indent(8) }}" | gpg --dry-run --import --batch --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }} 2>&1 | grep "unchanged: 1"
+        echo "{{ key_response.body|indent(8) }}
+        " | gpg --dry-run --import --batch --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }} 2>&1 | grep "unchanged: 1"
 {% endmacro %}
 
 {%- if grains['os_family'].lower() == 'debian' %}

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -31,6 +31,10 @@ datadog-apt-https:
   pkg.installed:
     - name: apt-transport-https
 
+datadog-gnupg:
+  pkg.installed:
+    - name: gnupg
+
 {# Create the keyring unless it exists #}
 {{ datadog_apt_usr_share_keyring }}:
   file.managed:

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -26,6 +26,19 @@
 {% set datadog_checks = datadog['checks'] %}
 {% set datadog_install_settings = datadog['install_settings'] %}
 
+{# Set constants for APT key management #}
+{% set datadog_apt_trusted_d_keyring = "/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg" %}
+{% set datadog_apt_usr_share_keyring = "/usr/share/keyrings/datadog-archive-keyring.gpg" %}
+{% set datadog_apt_key_current_name = "DATADOG_APT_KEY_CURRENT.public" %}
+# NOTE: we don't use URLs starting with https://keys.datadoghq.com/, as Python
+# on older Debian/Ubuntu doesn't support SNI and get_url would fail on them
+{% set datadog_apt_default_keys = {
+  datadog_apt_key_current_name: "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_CURRENT.public",
+  "D75CEA17048B9ACBF186794B32637D44F14F620E": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_F14F620E.public",
+  "A2923DFF56EDA6E76E55E492D3A80E30382E94DE": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_382E94DE.public",
+  }
+%}
+
 {# Determine if we're looking for the latest package or a specific version #}
 {%- if datadog_install_settings.agent_version == 'latest' %}
     {%- set latest_agent_version = true %}


### PR DESCRIPTION
### What does this PR do?

* By default, get keys from keys.datadoghq.com, not Ubuntu keyserver
* Always add the DATADOG_APT_KEY_CURRENT.public key (contains key used to sign current repodata)
* Add 'signed-by' option to all sources list lines
* On Debian >= 9 and Ubuntu >= 16, only add keys to /usr/share/keyrings/datadog-archive-keyring.gpg
* On older systems, also add the same keyring to /etc/apt/trusted.gpg.d

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
