### PR TITLE
Install datadog-signing-keys on Debian based platforms

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -143,3 +143,12 @@ datadog-pkg:
     - require:
       - pkgrepo: datadog-repo
     {%- endif %}
+
+{%- if grains['os_family'].lower() == 'debian' -%}
+  datadog-signing-keys-pkg:
+    pkg.installed:
+      - name: datadog-signing-keys
+      - version: 'latest'
+      - require:
+        - file: datadog-repo
+{%- endif -%}

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -144,7 +144,7 @@ datadog-pkg:
       - pkgrepo: datadog-repo
     {%- endif %}
 
-{%- if grains['os_family'].lower() == 'debian' -%}
+{%- if grains['os_family'].lower() == 'debian' %}
 datadog-signing-keys-pkg:
   pkg.installed:
     - name: datadog-signing-keys

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -145,10 +145,10 @@ datadog-pkg:
     {%- endif %}
 
 {%- if grains['os_family'].lower() == 'debian' -%}
-  datadog-signing-keys-pkg:
-    pkg.installed:
-      - name: datadog-signing-keys
-      - version: 'latest'
-      - require:
-        - file: datadog-repo
+datadog-signing-keys-pkg:
+  pkg.installed:
+    - name: datadog-signing-keys
+    - version: 'latest'
+    - require:
+      - file: datadog-repo
 {%- endif -%}

--- a/datadog/uninstall.sls
+++ b/datadog/uninstall.sls
@@ -7,5 +7,6 @@ datadog-uninstall:
   pkg.removed:
     - pkgs:
       - datadog-agent
+      - datadog-signing-keys
     - require:
       - service: datadog-uninstall


### PR DESCRIPTION
### What does this PR do?

Installs the new datadog-signing-keys package.

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
