### PR TITLE
Support Deployment to any Location

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_config, datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
+{% from "./map.jinja" import datadog_config, datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
 {% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
 {%- if not latest_agent_version and parsed_version[1] == '5' %}

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import datadog_config, datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
+{% from tpldir ~ "/map.jinja" import datadog_config, datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
 {% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
 {%- if not latest_agent_version and parsed_version[1] == '5' %}
@@ -10,6 +10,8 @@ datadog_conf_installed:
     - group: dd-agent
     - mode: 600
     - template: jinja
+    - context:
+        tpldir: {{ tpldir }}
     - require:
       - pkg: datadog-pkg
 {%- else %}
@@ -21,6 +23,8 @@ datadog_yaml_installed:
     - group: dd-agent
     - mode: 600
     - template: jinja
+    - context:
+        tpldir: {{ tpldir }}
     - require:
       - pkg: datadog-pkg
 {%- endif %}
@@ -57,6 +61,7 @@ datadog_{{ check_name }}_yaml_installed:
     - template: jinja
     - context:
         check_name: {{ check_name }}
+        tpldir: {{ tpldir }}
 
 {%- if latest_agent_version or parsed_version[1] != '5' %}
 {%- if datadog_checks[check_name].version is defined %}
@@ -86,5 +91,7 @@ install_info_installed:
     - group: dd-agent
     - mode: 600
     - template: jinja
+    - context:
+        tpldir: {{ tpldir }}
     - require:
       - pkg: datadog-pkg

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -5,7 +5,7 @@
 datadog_conf_installed:
   file.managed:
     - name: {{ config_file_path }}
-    - source: salt://datadog/files/datadog.conf.jinja
+    - source: salt://{{ tpldir }}/files/datadog.conf.jinja
     - user: dd-agent
     - group: dd-agent
     - mode: 600
@@ -16,7 +16,7 @@ datadog_conf_installed:
 datadog_yaml_installed:
   file.managed:
     - name: {{ config_file_path }}
-    - source: salt://datadog/files/datadog.yaml.jinja
+    - source: salt://{{ tpldir }}/files/datadog.yaml.jinja
     - user: dd-agent
     - group: dd-agent
     - mode: 600
@@ -50,7 +50,7 @@ datadog_{{ check_name }}_yaml_installed:
     {%- else %}
     - name: {{ datadog_install_settings.confd_path }}/{{ check_name }}.yaml
     {%- endif %}
-    - source: salt://datadog/files/conf.yaml.jinja
+    - source: salt://{{ tpldir }}/files/conf.yaml.jinja
     - user: dd-agent
     - group: root
     - mode: 600
@@ -81,7 +81,7 @@ datadog_check_{{ check_name }}_version_{{ datadog_checks[check_name].version }}_
 install_info_installed:
   file.managed:
     - name: {{ install_info_path }}
-    - source: salt://datadog/files/install_info.jinja
+    - source: salt://{{ tpldir }}/files/install_info.jinja
     - user: dd-agent
     - group: dd-agent
     - mode: 600

--- a/datadog/files/conf.yaml.jinja
+++ b/datadog/files/conf.yaml.jinja
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import datadog_checks with context -%}
+{% from tpldir ~ "/map.jinja" import datadog_checks with context -%}
 
 {% if datadog_checks[check_name].config is defined -%}
 

--- a/datadog/files/conf.yaml.jinja
+++ b/datadog/files/conf.yaml.jinja
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_checks with context -%}
+{% from "./map.jinja" import datadog_checks with context -%}
 
 {% if datadog_checks[check_name].config is defined -%}
 

--- a/datadog/files/datadog.conf.jinja
+++ b/datadog/files/datadog.conf.jinja
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_config with context -%}
+{% from "./map.jinja" import datadog_config with context -%}
 
 [Main]
 dd_url: https://app.datadoghq.com

--- a/datadog/files/datadog.conf.jinja
+++ b/datadog/files/datadog.conf.jinja
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import datadog_config with context -%}
+{% from tpldir ~ "/map.jinja" import datadog_config with context -%}
 
 [Main]
 dd_url: https://app.datadoghq.com

--- a/datadog/files/datadog.yaml.jinja
+++ b/datadog/files/datadog.yaml.jinja
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_config with context -%}
+{% from "./map.jinja" import datadog_config with context -%}
 
 {% if datadog_config.api_key is not defined -%}
 api_key:

--- a/datadog/files/datadog.yaml.jinja
+++ b/datadog/files/datadog.yaml.jinja
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import datadog_config with context -%}
+{% from tpldir ~ "/map.jinja" import datadog_config with context -%}
 
 {% if datadog_config.api_key is not defined -%}
 api_key:

--- a/datadog/files/install_info.jinja
+++ b/datadog/files/install_info.jinja
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import formula_version -%}
+{% from tpldir ~ "/map.jinja" import formula_version -%}
 ---
 install_method:
   tool: saltstack

--- a/datadog/files/install_info.jinja
+++ b/datadog/files/install_info.jinja
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import formula_version -%}
+{% from "./map.jinja" import formula_version -%}
 ---
 install_method:
   tool: saltstack

--- a/datadog/init.sls
+++ b/datadog/init.sls
@@ -1,4 +1,4 @@
 include:
-  - datadog.install
-  - datadog.config
-  - datadog.service
+  - .install
+  - .config
+  - .service

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import
+{% from "./map.jinja" import
     datadog_apt_default_keys,
     datadog_apt_trusted_d_keyring,
     datadog_apt_usr_share_keyring,

--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import
+{% from tpldir ~ "/map.jinja" import
     datadog_apt_default_keys,
     datadog_apt_trusted_d_keyring,
     datadog_apt_usr_share_keyring,

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
+{% from tpldir ~ "/map.jinja" import datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
 {% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
 datadog-agent-service:

--- a/datadog/service.sls
+++ b/datadog/service.sls
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
+{% from "./map.jinja" import datadog_install_settings, datadog_checks, latest_agent_version, parsed_version with context %}
 {% set config_file_path = '%s/%s'|format(datadog_install_settings.config_folder, datadog_install_settings.config_file) -%}
 
 datadog-agent-service:

--- a/datadog/uninstall.sls
+++ b/datadog/uninstall.sls
@@ -1,4 +1,4 @@
-{% from "datadog/map.jinja" import datadog_install_settings with context %}
+{% from "./map.jinja" import datadog_install_settings with context %}
 
 datadog-uninstall:
   service.dead:

--- a/datadog/uninstall.sls
+++ b/datadog/uninstall.sls
@@ -1,4 +1,4 @@
-{% from "./map.jinja" import datadog_install_settings with context %}
+{% from tpldir ~ "/map.jinja" import datadog_install_settings with context %}
 
 datadog-uninstall:
   service.dead:


### PR DESCRIPTION
### What does this PR do?

Implements usage of the [`tpldir`](https://docs.saltproject.io/en/latest/ref/states/vars.html#tpldir) SLS variable to make formula function independent of absolute path on the salt fileserver

### Motivation

Our salt fileserver has a pretty strict layout, and all formulas must go to `salt://formulas/...`.  This formula currently has some hard-references that expect it to exist at `salt://datadog`, which meant it wouldn't work out-of-the-box for us.  Rather than update the hardcoded paths, I decided to implement this in a way that would work regardless of where it's deployed.

### Additional Notes

Thanks for taking the time to put this together and publish it! Having even a starting point is great.  Would love to see it updated to support Windows installs, I may take a crack at that later as time allows.

### Describe your test plan

I tested this locally in my lab, applying to a Ubuntu 20.04 machine from both `salt://formulas/datadog` and `salt://datadog`.  In both cases it worked for me, but having a test in CI to make sure it works from multiple paths would ensure this behavior remains.  I'm not familiar enough with CircleCI to be comfortable implementing it without any conversation.
