### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,11 @@ commands:
 
   setup_ubuntu:
     steps:
-      - run: apt-get update && apt-get install -y curl sudo
+      - run: apt-get update && apt-get install -y curl sudo python3
       - run: cp test/utils/systemctl.py /bin/systemctl
       - run: cp test/utils/systemctl.py /bin/systemd
       - setup_common
+      - run: update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
   setup_centos:
     steps:

--- a/test/pillar/datadog5.sls
+++ b/test/pillar/datadog5.sls
@@ -11,4 +11,8 @@ datadog:
             name: "pillars"
 
   install_settings:
-    agent_version: 5.32.5
+    {% if grains['os_family'].lower() == 'redhat' %}
+    agent_version: 5.32.9
+    {% else %}
+    agent_version: 5.32.8
+    {% endif %}


### PR DESCRIPTION
### What does this PR do?

* Chooses proper 5.32 release to install based on distro]
* Selects python3 as the default Python (necessary for the `systemctl`/`systemd` shim).

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

Notes for the second point: It turns out that Saltstack used to install Python 2, but now it only installs Python 3. As a result, the `systemctl` shim couldn't find `/usr/bin/python` and failed to run. To fix this, we explicitly install Python 3 and use `update-alternatives` to set it as system's default Python.

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
