### PR TITLE
[CI] Fix CI by specifying hostname in containers

### DIFF
--- a/test/pillar/datadog.sls
+++ b/test/pillar/datadog.sls
@@ -3,6 +3,7 @@ datadog:
     api_key: aaaaaaaabbbbbbbbccccccccdddddddd
     site: datadoghq.com
     python_version: 2
+    hostname: test
 
   checks:
     directory:

--- a/test/pillar/datadog5.sls
+++ b/test/pillar/datadog5.sls
@@ -2,6 +2,7 @@ datadog:
   config:
     api_key: aaaaaaaabbbbbbbbccccccccdddddddd
     site: datadoghq.com
+    hostname: test-5
 
   checks:
     directory:

--- a/test/pillar/datadog6.sls
+++ b/test/pillar/datadog6.sls
@@ -3,6 +3,7 @@ datadog:
     api_key: aaaaaaaabbbbbbbbccccccccdddddddd
     site: datadoghq.com
     python_version: 2
+    hostname: test-6
 
   checks:
     directory:

--- a/test/pillar/datadog7.sls
+++ b/test/pillar/datadog7.sls
@@ -2,6 +2,7 @@ datadog:
   config:
     api_key: aaaaaaaabbbbbbbbccccccccdddddddd
     site: datadoghq.com
+    hostname: test-7
 
   checks:
     directory:


### PR DESCRIPTION
### What does this PR do?

<!--A brief description of the change being made with this pull request.-->
[Since 7.40.0](https://github.com/DataDog/datadog-agent/issues/14152), specifying a valid hostname is mandatory to be able to install & run the Agent service in a container. This repository's CI tries to install the Agent in containers, which is why we now need to specify an explicit hostname.

### Motivation

<!--What inspired you to submit this pull request?-->

Fix CI.

### Additional Notes

<!--Anything else we should know when reviewing?-->

n/a

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->

CI is green.
