### PR TITLE
TLS DEPRECATION: Use cloudfront for keys on Saltstack

### DIFF
--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -30,13 +30,11 @@
 {% set datadog_apt_trusted_d_keyring = "/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg" %}
 {% set datadog_apt_usr_share_keyring = "/usr/share/keyrings/datadog-archive-keyring.gpg" %}
 {% set datadog_apt_key_current_name = "DATADOG_APT_KEY_CURRENT.public" %}
-# NOTE: we don't use URLs starting with https://keys.datadoghq.com/, as Python
-# on older Debian/Ubuntu doesn't support SNI and get_url would fail on them
 {% set datadog_apt_default_keys = {
-  datadog_apt_key_current_name: "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_CURRENT.public",
-  "5F1E256061D813B125E156E8E6266D4AC0962C7D": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_C0962C7D.public",
-  "D75CEA17048B9ACBF186794B32637D44F14F620E": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_F14F620E.public",
-  "A2923DFF56EDA6E76E55E492D3A80E30382E94DE": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_382E94DE.public",
+  datadog_apt_key_current_name: "https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public",
+  "5F1E256061D813B125E156E8E6266D4AC0962C7D": "https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public",
+  "D75CEA17048B9ACBF186794B32637D44F14F620E": "https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public",
+  "A2923DFF56EDA6E76E55E492D3A80E30382E94DE": "https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public",
   }
 %}
 


### PR DESCRIPTION
### What does this PR do?

Use cloudfront instead raw s3 url to get public signing keys
NOTE; We disabled SNI on cloudfronts
<!--A brief description of the change being made with this pull request.-->

### Motivation

AWS S3 will deprecate TLS 1.0 and TLS 1.1 we need to switch to Cloudfront


<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
