### PR TITLE
[2024 GPG Key Rotation] Import new GPG future key

### DIFF
--- a/datadog/install.sls
+++ b/datadog/install.sls
@@ -119,7 +119,7 @@ datadog-repo:
     - name: datadog
     - baseurl: https://yum.datadoghq.com/{{ path }}/{{ grains['cpuarch'] }}
     - gpgcheck: '1'
-    - gpgkey: https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+    - gpgkey: https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_4F09D16B.public https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     - gpgautoimport: True
     - sslverify: '1'
 {%- endif %}

--- a/datadog/map.jinja
+++ b/datadog/map.jinja
@@ -35,6 +35,7 @@
 # on older Debian/Ubuntu doesn't support SNI and get_url would fail on them
 {% set datadog_apt_default_keys = {
   datadog_apt_key_current_name: "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_CURRENT.public",
+  "D18886567EABAD8B2D2526900D826EB906462314": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_06462314.public",
   "5F1E256061D813B125E156E8E6266D4AC0962C7D": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_C0962C7D.public",
   "D75CEA17048B9ACBF186794B32637D44F14F620E": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_F14F620E.public",
   "A2923DFF56EDA6E76E55E492D3A80E30382E94DE": "https://s3.amazonaws.com/public-signing-keys/DATADOG_APT_KEY_382E94DE.public",


### PR DESCRIPTION
### What does this PR do?

Import a new future GPG key
<!--A brief description of the change being made with this pull request.-->

### Motivation

<!--What inspired you to submit this pull request?-->
WIth the 2024 GPG key rotation ongoing customer will need to start trusting a new future GPG key that will be used in 2028.

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
