### PR TITLE
Manage additional files

### DIFF
--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -88,3 +88,10 @@ install_info_installed:
     - template: jinja
     - require:
       - pkg: datadog-pkg
+
+{% for filename, config in pillar.get('datadog:additional_config', {}).items() %}
+/etc/datadog-agent/{{ filename }}:
+  file.serialize:
+    - dataset: {{ config }}
+    - formatter: yaml
+{% endfor %}

--- a/datadog/config.sls
+++ b/datadog/config.sls
@@ -89,9 +89,16 @@ install_info_installed:
     - require:
       - pkg: datadog-pkg
 
-{% for filename, config in pillar.get('datadog:additional_config', {}).items() %}
+{% for filename, config in salt['pillar.get']('datadog:additional_config').items() %}
 /etc/datadog-agent/{{ filename }}:
   file.serialize:
     - dataset: {{ config }}
     - formatter: yaml
+    - user: dd-agent
+    - group: dd-agent
+    - mode: 600
+    - require:
+      - pkg: datadog-pkg
+    - watch_in:
+      - service: datadog-agent-service
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,20 @@ datadog:
     api_key: aaaaaaaabbbbbbbbccccccccdddddddd
     site: datadoghq.com
     python_version: 2
-
+  additional_config:
+    system-probe.yaml:
+      network_config:
+        enabled: false
+      runtime_security_config:
+        enabled: true
+      fim_enabled: true
+      remote_configuration:
+        enabled: true
+      custom_sensitive_words:
+        - 'personal_key'
+        - '*token'
+        - 'sql*'
+        - '*pass*d*'
   checks:
     process:
       config:


### PR DESCRIPTION
### What does this PR do?

This PR adds an additional section in pillar to produce additional config files in /etc/datadog-agent.  You include the contents of these yaml files into the datadog:additional_config pillar and salt will serialize that pillar data into the appropriate file.

### Motivation

I need to manage system-probe.yaml as well as security-agent.yaml in the /etc/datadog-agent directory and the formula didn't have a facility to do this.

### Additional Notes


### Describe your test plan

If you have the `additional_config` pillar structured like the below example, the formula will create `/etc/datadog-agent/system-probe.yaml` with the specified settings in place.

```
datadog:
  config:
    api_key: aaaaaaaabbbbbbbbccccccccdddddddd
    site: datadoghq.com
    python_version: 2
  additional_config:
    system-probe.yaml:
      network_config:
        enabled: false
      runtime_security_config:
        enabled: true
      fim_enabled: true
      remote_configuration:
        enabled: true
      custom_sensitive_words:
        - 'personal_key'
        - '*token'
        - 'sql*'
        - '*pass*d*'
 ```